### PR TITLE
Update pyats_addvlan.py

### DIFF
--- a/pyats_addvlan.py
+++ b/pyats_addvlan.py
@@ -38,13 +38,13 @@ class AddVlanToTrunk(aetest.Testcase):
     @aetest.cleanup
     def cleanup(self):
         self.device.disconnect()
-
+        
 if __name__ == '__main__':
     import argparse
     from pyats import topology
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--testbed', dest='testbed', type=topology.loader.load, required=True)
-    args, unknown = parser.parse_known_args()
-    
+    parser.add_argument('--testbed', dest='testbed', type=str, required=True)
+    args = parser.parse_args()
+
     aetest.main(testbed=args.testbed)


### PR DESCRIPTION
instead of this part:

if __name__ == '__main__':
    import argparse
    from pyats import topology

    parser = argparse.ArgumentParser()
    parser.add_argument('--testbed', dest='testbed', type=topology.loader.load, required=True)
    args, unknown = parser.parse_known_args()
    
    aetest.main(testbed=args.testbed)
    
we are going to use this part:

if __name__ == '__main__':
    import argparse
    from pyats import topology

    parser = argparse.ArgumentParser()
    parser.add_argument('--testbed', dest='testbed', type=str, required=True)
    args = parser.parse_args()

    aetest.main(testbed=args.testbed)